### PR TITLE
prevent panic when CFPreferences key is unset

### DIFF
--- a/cfpref/cfpref.go
+++ b/cfpref/cfpref.go
@@ -32,8 +32,11 @@ type CFPropertyListRef struct {
 }
 
 // CFTypeID returns the CFTypeID of a CFPropertyListRef
-func (plisRef CFPropertyListRef) CFTypeID() CFTypeID {
-	typeId := C.CFGetTypeID(C.CFTypeRef(plisRef.ref))
+func (plistRef CFPropertyListRef) CFTypeID() CFTypeID {
+	if plistRef.ref == nil {
+		return Null
+	}
+	typeId := C.CFGetTypeID(C.CFTypeRef(plistRef.ref))
 	return CFTypeID(typeId)
 }
 

--- a/cfpref/cfpref_test.go
+++ b/cfpref/cfpref_test.go
@@ -1,0 +1,34 @@
+package cfpref
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestCopyAppValue(t *testing.T) {
+	type args struct {
+		key   string
+		appID string
+	}
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		{
+			name: "default",
+			args: args{key: "HomePage", appID: "com.apple.safari"},
+			want: "www.apple.com",
+		},
+		{
+			name: "unset",
+			args: args{key: "FooBarBaz", appID: "com.apple.safari"},
+			want: "www.apple.com",
+		},
+	}
+	for _, tt := range tests {
+		if got := CopyAppValue(tt.args.key, tt.args.appID); !reflect.DeepEqual(got, tt.want) {
+			t.Errorf("%q. CopyAppValue() = %v, want %v", tt.name, got, tt.want)
+		}
+	}
+}


### PR DESCRIPTION
if the return is nil, sets the CFTypeID to Null

Closes #1